### PR TITLE
Content quiz reading logs util

### DIFF
--- a/util/reading_logs.py
+++ b/util/reading_logs.py
@@ -146,7 +146,7 @@ class ReadingLogsData:
             return page_content_quiz_df['num_before_ans'][f'{data448_id}'], None
 
         all_num_attempts = [num for num in page_content_quiz_df['num_before_ans'].values if num != -1]
-        return mean_and_sd(all_num_attempts)
+        return aggregate_and_sd(all_num_attempts)
 
     def module_content_quiz_num_attempts(self, module_num: int, data448_id: int = None) -> (float, float):
         content_quiz_attempts_per_page = []
@@ -155,7 +155,7 @@ class ReadingLogsData:
             average_num_attempts, _ = self.page_content_quiz_num_attempts(module_num, int(page_num), data448_id)
             content_quiz_attempts_per_page.append(average_num_attempts)
 
-        return mean_and_sd(content_quiz_attempts_per_page)
+        return aggregate_and_sd(content_quiz_attempts_per_page)
 
     def get_paragraph_list(self, module_num: int, page_num: int) -> [str]:
         module_paragraphs_dict = self.get_module_paragraphs_dict()

--- a/util/reading_logs.py
+++ b/util/reading_logs.py
@@ -118,6 +118,7 @@ class ReadingLogsData:
         :return: (float representing the average number of content quiz attempts, standard deviation for this average)
         """
         page_content_quiz_df = self.get_content_quiz_performance_dict()[f'{module_num}-{page_num}']
+        TAMPERED = -1
 
         def num_before_ans(*args):
             q_response_lists = []
@@ -126,7 +127,7 @@ class ReadingLogsData:
 
             # Discard if they tampered with the numbers so questions have a different number of attempts
             if not all(len(response_set) == len(q_response_lists[0]) for response_set in q_response_lists):
-                return -1
+                return TAMPERED
 
             all_correct = ['ans'] * len(q_response_lists)
             count = 0
@@ -145,7 +146,7 @@ class ReadingLogsData:
         if data448_id:
             return page_content_quiz_df['num_before_ans'][f'{data448_id}'], None
 
-        all_num_attempts = [num for num in page_content_quiz_df['num_before_ans'].values if num != -1]
+        all_num_attempts = [num for num in page_content_quiz_df['num_before_ans'].values if num != TAMPERED]
         return aggregate_and_sd(all_num_attempts)
 
     def module_content_quiz_num_attempts(self, module_num: int, data448_id: int = None) -> (float, float):

--- a/util/reading_logs.py
+++ b/util/reading_logs.py
@@ -120,18 +120,18 @@ class ReadingLogsData:
         page_content_quiz_df = self.get_content_quiz_performance_dict()[f'{module_num}-{page_num}']
 
         def num_before_ans(*args):
-            lists = []
+            q_response_lists = []
             for val in args:
-                lists.append(val) if isinstance(val, list) else lists.append([val])
+                q_response_lists.append(val) if isinstance(val, list) else q_response_lists.append([val])
 
             # Discard if they tampered with the numbers so questions have a different number of attempts
-            if not all(len(response_set) == len(lists[0]) for response_set in lists):
+            if not all(len(response_set) == len(q_response_lists[0]) for response_set in q_response_lists):
                 return -1
 
-            all_correct = ['ans'] * len(lists)
+            all_correct = ['ans'] * len(q_response_lists)
             count = 0
-            for question_responses in zip(*lists):
-                if list(question_responses) == all_correct:
+            for q_response_set in zip(*q_response_lists):
+                if list(q_response_set) == all_correct:
                     return count
                 else:
                     count += 1
@@ -233,9 +233,3 @@ def aggregate_and_sd(values: [], mean=True) -> (float, float):
         return mean, sd
     else:
         return sum(values_list), sd
-
-
-def get_text_difficulty_index(module_num: int, page_num: int = None) -> float:
-    # TODO: read the data stored about the difficulty of each module/page and return the correctly difficulty index
-    # TODO: switch so 0 means easy and 1 means difficult
-    return 1


### PR DESCRIPTION
+ messy implementation of content quiz attempt num

I don't know if this does what everyone needs, but this was kind of a mess, admittedly.

It currently does work to calculate the average number of attempts it took a student before they got all questions correct (since it's possible to keep submitting after you get a question correct)

It's a bit complicated to do this because of how the data is stored in the data frames but I tried my best.  reckoned @MtheDV and @carson-ricca could merge this in the meantime to complete their tasks while @nononovia and @Rick-Feng-u finish reviewing and improving this code. 