### PR TITLE
Fix content quiz num attempts calculation

### DIFF
--- a/util/reading_logs.py
+++ b/util/reading_logs.py
@@ -133,7 +133,7 @@ class ReadingLogsData:
             count = 0
             for q_response_set in zip(*q_response_lists):
                 if list(q_response_set) == all_correct:
-                    return count
+                    return count / len(q_response_lists)
                 else:
                     count += 1
 


### PR DESCRIPTION
+ adjust reading logs content quiz num attempts to account for the number of questions

TODO: This fix makes the function return numbers that are divided by the number of questions so:
e.g. Student A solves page 5-2 content quiz (that has 2 questions) in 1 try. Function returns => 0/2 = 0
e.g. Student B solves page 5-3 content quiz (that has 3 questions) in 2 tries. Function returns => 1/3 = 0.33...

It's supposed to represent `(number of extra attempts needed) / (number of questions in a content quiz)`.

Problem to solve: @Rick-Feng-u @nononovia @MtheDV 
-> Is it okay to have value `0` mean that a student solved the quiz in 1 try
    -> If we decide this is not okay, it's not as simple as just making it 1 instead because then solving a 2-question quiz in 1 try gives `value=0.5` and solving a 3-question quiz in 1 try gives `value=0.33..` which feels bad to me
    
Close #91 