### PR TITLE
Fix parse reading logs oopsie

### DIFF
--- a/scripts/reading_logs/parse_reading_logs/parse_reading_logs.py
+++ b/scripts/reading_logs/parse_reading_logs/parse_reading_logs.py
@@ -119,6 +119,8 @@ def parsing_each_continue(reading_log_folder_path: str, module_number: str, data
         page_num = reading_log.split('-')[2]
         if not page_num.isnumeric():
             continue
+        if data448_id in module[f'{module_number}-{page_num}'].index:
+            continue
 
         with open(reading_log_path, 'r') as f:
             try:
@@ -163,6 +165,8 @@ def parsing_each_quiz_submit(reading_log_folder_path: str, module_number: str, d
         # at index 1 is module number and index 2 is page number
         page_num = reading_log_name_array[2]
         if not page_num.isnumeric():
+            continue
+        if data448_id in module[f'{module_number}-{page_num}'].index:
             continue
 
         with open(reading_log_path, 'r') as f:

--- a/util/reading_logs.py
+++ b/util/reading_logs.py
@@ -1,9 +1,8 @@
 import json
 import os
-import statistics
 
 import dill
-import pandas as pd
+import numpy as np
 
 from schemas import CourseSchema
 from util import MODULE_PARAGRAPHS_OUTPUT_FILEPATH, CACHE_FOLDER
@@ -255,7 +254,7 @@ def ms_to_minutes(duration_ms: float):
 def aggregate_and_sd(values: [], mean=True) -> (float, float):
     values_list = list(values)
     if len(values_list) > 1:
-        sd = statistics.stdev(values_list)
+        sd = np.std(values_list)
     else:
         sd = 0
     if mean:


### PR DESCRIPTION
+ handle the case where someone hands in 2 reading log files for the same page
+ also switch standard deviation library call to numpy.std (for some reason statistics.stdev has strange behaviour)

The code wasn't handling when people handed in multiple reading logs for the same page. The way it did things was by appending series' to the dataframe. But when you append a series to a dataframe that already contains that index it makes essentially a series within the series. Data type super pain, crashes averaging

tldr; data/api/canvas/reading_logs/741743/4006013/ -> look for reading log '5-3', we weren't handling that, now we are.

Closes #99 